### PR TITLE
Remove explicit onMounted

### DIFF
--- a/pages/Events.vue
+++ b/pages/Events.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { onMounted } from 'vue'
 import { initModals, initTooltips } from 'flowbite'
 
 // initialize components based on data attribute selectors


### PR DESCRIPTION
Don't need to explicitly import the `onMounted` function, it's already baked in to the script setup. Same can be done for all the other pages in this app.